### PR TITLE
adding upper case sambadomain

### DIFF
--- a/ldapwrapper.js
+++ b/ldapwrapper.js
@@ -66,7 +66,7 @@ ldapwrapper.do = async function () {
     }
 
     db[LDAP_SAMBA] = {
-       "sambaDomainName": sambaDomainName
+       "sambaDomainName": sambaDomainName.toUpperCase()
       ,"sambaLogonToChgPwd": 0
       ,"sambaLockoutObservationWindow": 30
       ,"sambaMaxPwdAge": -1


### PR DESCRIPTION
# Minor correction: upper case sambadomain

## Context
By default, samba use upper case sambaDomainName and is not able to find it. Connection from samba to the ldap server was impossible. 
*view netbios name in smb.conf*.

## Changes
Changed the "sambaDomainName" attribute to be in upper case to respect the standard configuration of samba configs.