### PR TITLE
do not specify LDAP_BASEDN in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apk add --no-cache tini su-exec
 
 ENV NODE_ENV "production"
 ENV LDAP_DOMAIN "example.com"
-ENV LDAP_BASEDN "dc=example,dc=com"
 ENV LDAP_BINDUSER "username|password"
 ENV LDAP_PORT "13389"
 ENV LDAP_DEBUG "false"


### PR DESCRIPTION
this config value is generated from env var LDAP\_DOMAIN automatically, but the default value in Dockerfile is used because it is specified in the Dockerfile ( also affects LDAP\_GROUPSDN, LDAP\_USERSDN, LDAP\_USERSGROUPSBASEDN and LDAP\_SAMBADOMAINNAME )
