### PR TITLE
Make tini PID 1 process in container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,4 @@ else
   su_exec_cmd="su-exec root:root"
 fi
 
-$su_exec_cmd /sbin/tini -s -- $node_path --openssl-legacy-provider index.js
+exec $su_exec_cmd /sbin/tini -s -- $node_path --openssl-legacy-provider index.js


### PR DESCRIPTION
In current state container does not respond to SIGTERM signal when stopped. After timeout SIGKILL signal needs to be used. This patch uses exec in entrypoint script and makes tini PID 1 process in the container. It then responses correctly to SIGTERM signal. 